### PR TITLE
update README to point to new C# SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+
+---
+**IMPORTANT:**
+
+**This C# SDK has been replaced by the following C# SDK:**
+
+https://github.com/PitneyBowes/pitneybowes-shipping-api-csharp-openapi
+
+**Please see the new SDK. The SDK on this page is deprecated. For current users, this SDK will continue to work but will not include updated features.**
+
+---
+
 # Pitney Bowes Shipping API C# Client
 
 **Latest version 1.3.0 is not backward compatiable with older versions as Surcharge Enum from Rates object has been removed and now it's a string**


### PR DESCRIPTION
@am005si, @na003za, This commit adds an "Important" block at the top of the README to point to the new SDK and to say this SDK is deprecated.


